### PR TITLE
Changed code for responsive design

### DIFF
--- a/src/js/accordion.js
+++ b/src/js/accordion.js
@@ -1,30 +1,111 @@
-var items = $(".acc-item"),
-activeItem = null;
+var items = $(".item"),
+    titles = $(".title"),
+    contentContainers = $(".content-container"),
+    activeItem = null;
 
-$.each(items, function(i, e) {
-	var content = $(e).children(".acc-content");
-	t = TweenLite.from(content, 0.5, {
-		height: 0,
-		paused: true,
-		reversed: true
-	});
-	e.toggleAnimation = t;
+$.each(contentContainers, function(i,e){
+
+  createAccordionTween(e);
+
 });
 
-items.tap(function(){
-	var _this = this,
-	$self = $(this),
-	$selfIndex = items.index($self);
+$(window).resize(function(){
+
+  $.each(contentContainers, function(i,e) {
+
+    createAccordionTween(e, i);
+
+  });
+
+});
+
+
+
+/*
+  this function creates the tween for the accordion item
+  records the height of the element and then creates a fromTo() instance. Also records the current progress of the element's tween (if any) and then takes the new instance to that point (this only for the active item - if there's an item currently animating)
+  the function's target should be a regular DOM element.
+  in this case the function will be called in a loop that will pass the DOM element
+*/
+function createAccordionTween(target, index) {
+    
+  // clear the height property of previous animations
+  TweenLite.set(target, {clearProps:"height"});
+
+  var _this = target,
+      $this = $(target),
+      targetAnimation = _this.toggleAnimation,// null on the first pass
+      /*
+        get the paused state to determinate the playhead's direction.
+        if the tween exists get the state (could be true or false)
+        if the tween doesn't exists set the paused state to null, 
+        in this case the animation will be created for the first time
+        and we don't care about the playhead's direction.
+      */
+      targetAnimationActive = targetAnimation ? targetAnimation.isActive() : null,
+      // same with the reversed state
+      targetAnimationReversed = targetAnimation ? targetAnimation.reversed() : true,
+      // get the current's animation progress, if the animation exists
+      targetAnimationProg = targetAnimation ? targetAnimation.progress() : 0,
+      $thisHeight = $this.outerHeight(),
+      // create the new tween and set the current progress
+      t = TweenLite.fromTo(_this, 1, {height:0}, {height:$thisHeight, paused:true}).progress(targetAnimationProg);
+
+  /*
+    check the direction of the playhead only if the animation was active
+    if the animation is going forward => play() else => reverse()
+  */
+  if( targetAnimationActive ) {
+
+    targetAnimationReversed ? t.reverse() : t.play();
+
+  }
+
+  // attach the animation to the DOM element
+  _this.toggleAnimation = t;
+
+}
+
+/*
+*  CLICK EVENT
+*/
+titles.click(function(){
+
+	var targetContent = $(this).siblings(".content-container")[0],
+	targetAnimation = targetContent.toggleAnimation,
+	$this = $(this),
+	$thisIndex = titles.index($this);
 	
-	if ($selfIndex !== activeItem && activeItem !== null) {
-		items[activeItem].toggleAnimation.reverse();
-		this.toggleAnimation.play();
-		activeItem = $selfIndex;
-	}else if (activeItem === null){
-		this.toggleAnimation.play();
-		activeItem = $selfIndex;
-	}else{
-		this.toggleAnimation.reverse();
+	if($thisIndex !== activeItem && activeItem !== null) {
+	
+		contentContainers[activeItem].toggleAnimation.reverse();
+		// remove the active class
+		$(".active-accordion").removeClass("active-accordion");
+		
+		// add the active class to this element
+		$this.addClass("active-accordion");
+		
+		targetAnimation.play();
+		
+		activeItem = $thisIndex;
+	
+	} else if(activeItem === null) {
+	
+		// add the active class to this element
+		$this.addClass("active-accordion");
+		
+		targetAnimation.play();
+		
+		activeItem = $thisIndex;
+	
+	} else {
+	
+		// remove the active class
+		$(".active-accordion").removeClass("active-accordion");
+		
+		targetAnimation.reverse();
+		
 		activeItem = null;
 	}
+	
 });


### PR DESCRIPTION
As mentioned earlier the code needed some changes to accommodate RWD.
### Some Background

In RWD changing the screen width normally imposes changes on DOM elements' properties like width, font size and line height among others. This ultimately means that the element's height will change as well.
### GSAP and some RWD issues

One of the key features of GSAP is speed and one of the reasons for that is that it's highly optimized. One of this optimizations is avoiding layout trashing, which means constant read-write operations from-to the DOM.
Upon instantiation GSAP records the starting and ending values of the properties to animate (height in this case) in a lookup table. Then iterates between those values and the CSS Plugin applies those values to the element. Because of this, if the starting or ending values changes after the instance was created GSAP won't know about this changes so it'll keep applying the original values which means odd rendering. In order to avoid this a function creates the animation instance for every element and for orientation changes some values are stored for later use. These are:
- Boolean to check if the animation is active. Only important if the orientation change (OC) happens while the animation is happening. If the animation hasn't started or it's completed this is irrelevant.
- Boolean to check the playing direction. Again only important if the animation was playing during OC, in order to restore the direction after creating the instance again.
- Number, animation progress. Also important if the animation is playing. Is important to take the new instance to the position it had when the OC happened, specially if an easing function is being used.
- Number, element's new height. We record the new height in order to know between which values the iteration has to be done.
  After getting those values we create the new instance with the new height and move the playhead to the recorded progress to create a seamless transition. Finally if the animation was playing/reversing during the OC, the new instance (that it was created paused) it's resumed in the proper direction.
### Live Sample

http://codepen.io/rhernando/debug/700a72e818449d5ed8dd23b56f50741c
### HTML & CSS Markup

http://codepen.io/rhernando/pen/700a72e818449d5ed8dd23b56f50741c

Finally it would be nice to have a subfolder for this and other classes coming up in the future, in order to upload HTML samples as well.

In this one I wrapped the content into another container just to add some padding to it, because padding is a bit more tricky to work with when animating the height to zero, you have to animate the padding values as well.

Finally the duration can be changed in line 52.

Best,
Rodrigo.
